### PR TITLE
Added isoPublishDate to Item Metadata, can be used in the template

### DIFF
--- a/site/template/header.html
+++ b/site/template/header.html
@@ -7,7 +7,29 @@
     <link rel="stylesheet" href="/css/pico.min.css">
     <link rel="stylesheet" href="/css/extra.css">
     <link rel="icon" type="image/png" href="/images/favicon.png">
-    <title>{{title}}</title>
+
+    {{! opengraph tags for social media }}
+    <meta property="og:locale" content="ro_RO" />
+    <meta property="og:site_name" content="☭ evie" />
+    {{! <meta property="og:image" content="https://example.com/image.jpg" /> }}
+    <meta property="og:url" content="https://example.com/" /> {{! this is incorrect, it should be the absolute URL of the page }}
+    <meta property="og:description" content="Content descripton" />
+
+    {{^post}}
+    {{! if we don't have a post, we assume we're in index (but we could be in a page or a tag ) }}
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="☭ evie" />
+    {{/post}}
+
+    {{#post}}
+    {{! if we're in a post, customize the opengraph tags to suit }}
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="{{title}}" />
+    <meta property="article:publisher" content="https://example.com/" />
+    <meta property="article:published_time" content="{{isoPublishDate}}" />
+    {{/post}}
+
+    <title>☭ evie{{#post.title}} | {{.}}{{/post.title}}</title>
   </head>
   <body class="container">
 


### PR DESCRIPTION
The publish date in ISO8601 format is useful for adding metadata tags to the template and generated output files (for example, in Open Graph article:published_time).